### PR TITLE
Remove unnecessary iolist_to_binary step

### DIFF
--- a/lib/ex_aliyun_sls/client.ex
+++ b/lib/ex_aliyun_sls/client.ex
@@ -21,9 +21,7 @@ defmodule ExAliyunSls.Client do
       Topic: topic
     }
     {iodata, size} = LogGroup.encode!(log_group)
-    iodata
-    |> :erlang.iolist_to_binary()
-    |> request_api(size, profile)
+    iodata |> request_api(size, profile)
   end
 
   defp request_api(body, body_length, profile) do


### PR DESCRIPTION
Here is the implementation of `:crypto.hash/2` in Erlang:

```erlang
-doc(#{title => <<"Hash API">>,
       since => <<"OTP R15B02">>}).
-spec hash(Type, Data) -> Digest when Type :: hash_algorithm(),
                                      Data :: iodata(),
                                      Digest :: binary().
hash(Type, Data) ->
    Data1 = iolist_to_binary(Data),
    MaxBytes = max_bytes(),
    hash(Type, Data1, erlang:byte_size(Data1), MaxBytes).
```

I suppose it's unnecessary to evaluate the duplicated `iolist_to_binary` in client.ex